### PR TITLE
Miscellaneous fixes

### DIFF
--- a/ass_diskrules
+++ b/ass_diskrules
@@ -30,7 +30,7 @@ SPECS		:= -B ../devkit68K/m68k-elf/lib -specs=asspull-disk.specs
 INCLUDE		:= # -I toolinclude
 LIBPATHS	:=
 
-CFLAGS		:= $(INCLUDE) -Wall -fno-strict-aliasing -fomit-frame-pointer $(ARCH)
+CFLAGS		:= $(INCLUDE) -Wall -Os -fno-strict-aliasing -fomit-frame-pointer $(ARCH)
 ASFLAGS		:= -x assembler-with-cpp -c $(ARCH) -Wall
 LDFLAGS		:= $(ARCH) $(SPECS) $(LIBPATHS) $(LIBS)
 

--- a/ass_diskrules
+++ b/ass_diskrules
@@ -25,7 +25,7 @@ GRITFLAGS := -ftc -fh! -gu8
 MAPFILE		:= $(TARGET).map
 
 ARCH		:= -m68000
-SPECS		:= -specs=asspull-disk.specs
+SPECS		:= -B ../devkit68K/m68k-elf/lib -specs=asspull-disk.specs
 
 INCLUDE		:= # -I toolinclude
 LIBPATHS	:=

--- a/ass_diskrules
+++ b/ass_diskrules
@@ -41,6 +41,7 @@ LDFLAGS += -Wl,-Map $(MAPFILE) -nostartfiles
 # ---------------------------------------------------------------------
 
 ../_disk2_/$(TARGET).app : $(TARGET).elf
+	mkdir -p ../_disk2_
 	$(OBJCOPY) -O binary $< $@
 #	$(CROSS)objdump -d $(TARGET).elf > $(TARGET).txt
 

--- a/ass_romrules
+++ b/ass_romrules
@@ -25,7 +25,7 @@ GRITFLAGS := -ftc -fh! -gu8
 MAPFILE		:= $(TARGET).map
 
 ARCH    	:= -m68000
-SPECS		:= -specs=asspull.specs
+SPECS		:= -B ../devkit68K/m68k-elf/lib -specs=asspull.specs
 
 INCLUDE		:= -I toolinclude
 LIBPATHS	:=

--- a/ass_romrules
+++ b/ass_romrules
@@ -30,7 +30,7 @@ SPECS		:= -B ../devkit68K/m68k-elf/lib -specs=asspull.specs
 INCLUDE		:= -I toolinclude
 LIBPATHS	:=
 
-CFLAGS		:= $(INCLUDE) -Wall -Wextra -fno-strict-aliasing -fomit-frame-pointer $(ARCH)
+CFLAGS		:= $(INCLUDE) -Wall -Wextra -Os -fno-strict-aliasing -fomit-frame-pointer $(ARCH)
 ASFLAGS		:= -x assembler-with-cpp -c $(ARCH) -Wall
 LDFLAGS		:= $(ARCH) $(SPECS) $(LIBPATHS) $(LIBS)
 

--- a/bios/Makefile
+++ b/bios/Makefile
@@ -25,7 +25,7 @@ export OFILES	:= $(SFILES:.s=.o) $(CFILES:.c=.o)
 MAPFILE		:= $(TARGET).map
 
 ARCH		:= -m68000
-SPECS		:= -specs=asspull-bios.specs
+SPECS		:= -B ../devkit68K/m68k-elf/lib -specs=asspull-bios.specs
 
 INCLUDE		:= -I toolinclude
 LIBPATHS	:=

--- a/bios/crt0.s
+++ b/bios/crt0.s
@@ -78,10 +78,9 @@ initialize:
 	lea		0x01000000,%a1
 	move.l	#_sdata,%d0
 	lsr.l	#1,%d0
-	subq.w	#1,%d0
-2:
-	move.w	(%a0)+,(%a1)+
-	dbra	%d0,2b
+	bra.b	2f
+1:	move.w	(%a0)+,(%a1)+
+2:	dbra	%d0,1b
 
 	lea		0x013F0000,%a0
 	movea.l	%a0,%sp			| set stack pointer to top of Work RAM

--- a/crt0.s
+++ b/crt0.s
@@ -8,9 +8,9 @@ initialize:
 	lea     0x01001000,%a1
 	move.l  #_sdata,%d0
 	lsr.l   #1,%d0
-	subq.w  #1,%d0
-2:	move.w  (%a0)+,(%a1)+
-	dbra    %d0,2b
+	bra.b   2f
+1:	move.w  (%a0)+,(%a1)+
+2:	dbra    %d0,1b
 
 	lea     0x013F0000,%a0
 	movea.l %a0,%sp

--- a/crt0_disk.s
+++ b/crt0_disk.s
@@ -8,9 +8,9 @@ initialize:
 	lea		0x01040000,%a1
 	move.l	#_sdata,%d0
 	lsr.l	#1,%d0
-	subq.w	#1,%d0
-2:	move.w	(%a0)+,(%a1)+
-	dbra	%d0,2b
+	bra.b	2f
+1:	move.w	(%a0)+,(%a1)+
+2:	dbra	%d0,1b
 	move.l  #0x01000000,interface
 	jsr		main
 	rts


### PR DESCRIPTION
- Add linker scripts to compiler search path
- Automatically create _disk2_ directory
- Enable compiler optimizations for roms/disks
- Fix copy routines for zero-sized data sections