### PR TITLE
Assign VBlank to IRQ 6 and HBlank to IRQ 4

### DIFF
--- a/ass.h
+++ b/ass.h
@@ -111,7 +111,8 @@
 #define SMODE_200 0x80		// Specifies that bitmap modes should be 200 or 400 lines.
 
 #define IMODE_DISABLE	0x80	// Enable interrupts.
-#define IMODE_INVBLANK	0x04	// VBlank is triggered.
+#define IMODE_INVBLANK	0x04	// VBlank is active.
+#define IMODE_INHBLANK	0x02	// HBlank is active.
 
 #define PCM_REPEAT		0x80000000
 
@@ -361,9 +362,9 @@ typedef struct
 	long AssBang;
 	int16_t biosVersion;
 	int16_t extensions;
-	void(*Exception)(void);
-	void(*VBlank)(void);
-	void(*reserved)(void);
+	void(*Exception)(void*);
+	void(*VBlank)(void*);
+	void(*HBlank)(void*);
 	void(*DrawChar)(unsigned char, int, int, int);
 	ITextLibrary* textLibrary;
 	IDrawingLibrary* drawingLibrary;

--- a/bios/f_misc.c
+++ b/bios/f_misc.c
@@ -47,8 +47,6 @@ void WaitForVBlank()
 //	intoff();
 //	while(REG_LINE >= 480);
 //	while(REG_LINE < 480);
-	if (interface->VBlank)
-		interface->VBlank();
 }
 
 void WaitForVBlanks(int vbls)

--- a/bios/main.c
+++ b/bios/main.c
@@ -390,14 +390,3 @@ void ZeroHandler()
 	while(1) WaitForVBlank();
 	asm("rte");
 }
-
-void NMIHandler()
-{
-	int interrupts = REG_INTRMODE;
-	if (interrupts & IMODE_INVBLANK)
-	{
-		if (interface->VBlank != 0) interface->VBlank();
-		REG_INTRMODE &= ~IMODE_INVBLANK;
-	}
-	asm("rte");
-}

--- a/crt0.s
+++ b/crt0.s
@@ -16,6 +16,8 @@ initialize:
 	movea.l %a0,%sp
 	move.l  #0x01000000,interface
 	link.w  %a6,#-8
+
+	move    #0x2000,%sr     | enable interrupts
 	jsr     main
 3:	bra.b   3b
 

--- a/crt0_disk.s
+++ b/crt0_disk.s
@@ -12,6 +12,8 @@ initialize:
 1:	move.w	(%a0)+,(%a1)+
 2:	dbra	%d0,1b
 	move.l  #0x01000000,interface
+
+	move	#0x2000,%sr		| enable interrupts
 	jsr		main
 	rts
 3:	bra.b	3b


### PR DESCRIPTION
Rather than a single NMI for VBlank, separate maskable interrupts are now raised for VBlank and HBlank. Add BIOS support for this.

Unlike the old NMI handler, the new handlers are written in assembly so the full register context - including volatile registers a0-a1 and d0-d1 - is restored before returning.

The user callbacks now take a pointer to the exception frame as a parameter, though it can be safely ignored unless the application wants to do something advanced like inspect the program counter or re-enable interrupts before returning from the callback.